### PR TITLE
Disable TBA publication link

### DIFF
--- a/src/components/Publications/SinglePublication.tsx
+++ b/src/components/Publications/SinglePublication.tsx
@@ -23,9 +23,13 @@ const SinglePublication = ({ publications, years, selectedYear, setSelectedYear,
                 </button>
                 <div className="accordion-content">
                   <p>
-                    <a className="publink" href={t.publink} target="_blank" rel="noopener noreferrer">
-                      {t.content}
-                    </a>
+                    {t.publink === "TBA" ? (
+                      <span>{t.content}</span>
+                    ) : (
+                      <a className="publink" href={t.publink} target="_blank" rel="noopener noreferrer">
+                        {t.content}
+                      </a>
+                    )}
                     {t.flyer && (
                       <>
                         {" | "}


### PR DESCRIPTION
## Summary
- Disable publication links when the publication URL is the `TBA` placeholder.
- Keep the visible `TBA` text for the pending FEAT publication, but render it as plain text instead of `<a href="TBA">`.

Fixes #64.

## Validation
- `npm ci`
- `npm run lint` passed
- `git diff --check` passed
- Claude Code CLI review: PASS

## Note
- `npm run build` compiles and type-checks successfully, then fails during prerendering `/` with an existing `ReferenceError: document is not defined` from the page bundle. This does not appear related to the publication-link change.
- `npx prettier --check src/components/Publications/SinglePublication.tsx` is blocked because the repository config references `prettier-plugin-tailwindcss`, but the package is not present in `package.json` / `package-lock.json`.